### PR TITLE
Font validator: Actually support supplementary-plane code points

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ gradlePlugin {
 }
 
 group = "myaa"
-version = "0.1.19"
+version = "0.1.21"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
It complained and failed our build when an emoji was used. This fixes it.